### PR TITLE
Header 크기 조정 및 리팩토링

### DIFF
--- a/front/src/components/Header.js
+++ b/front/src/components/Header.js
@@ -24,7 +24,8 @@ function Header() {
 }
 
 const HeaderContainer = styled.div`
-    max-height: 5em;
+    height: 4em;
+    // width: 100vw;
     font-size: 1em;
     margin: 0 auto;
     display: flex;
@@ -33,13 +34,13 @@ const HeaderContainer = styled.div`
 `
 
 const Logo = styled.div`
-    width: 20%;
-    margin-right: 5%;
-    padding-top: 0.1%;
+    width: 30%;
+    margin-right: 3vh;
+    margin-top: 0.5vh;
 `
 
 const LogoImgSection = styled.img`
-    width: 100%;
+    width: 35vh;
 `
 const Nav = styled.nav`
     width: 70%;
@@ -48,8 +49,7 @@ const NavList = styled.ul`
     display: flex;
     text-align: center;
     align-items: center;
-    font-size: 1em;
-    margin-right: 3%;
+    font-size: 1.8vh;
     font-family: AkiraExpanded;
 `
 
@@ -59,8 +59,8 @@ const NavItem = styled.li`
 `
 
 const ResultBtn = styled.button`
-    padding: 3% 10% 3% 10%;
-    margin: 1%;
+    padding: 1vh 3vh 1vh 3vh;
+    margin: 1vh;
     font-size: 1em;
     font-family: AkiraExpanded; 
     border-radius: 3em;
@@ -71,8 +71,8 @@ const ResultBtn = styled.button`
     &:hover{
         background: linear-gradient(to right, #4285ec, #0bbafb);
         color: white;
-        border: none;
-        transition: 0.5s;
+        border: 0.2em solid white;
+        // transition: 0.2s; // 애니메이션 임시 주석
     }
 `
 

--- a/front/src/components/Header.js
+++ b/front/src/components/Header.js
@@ -63,8 +63,8 @@ const ResultBtn = styled.button`
     margin: 1%;
     font-size: 1em;
     font-family: AkiraExpanded; 
-    border-radius: 20px;
-    border: 2.5px solid black;
+    border-radius: 3em;
+    border: 0.2em solid black;
     background-color: white;
     white-space : nowrap;
 


### PR DESCRIPTION
### Header 크기 조정 및 리팩토링

기존 코드에서 Header의 크기를 줄였습니다.
또한 Footer를 구현하면서 웹 사이즈가 작아졌을 때 Header의 width 사이즈가 비정상적인 것을 확인했습니다.
비록 반응형은 아니지만, 웹 사이즈에 구애받지 않고 요소들이 동일한 크기를 유지하게끔 코드를 수정했습니다.

추가적으로 코드 내에서 px 단위를 사용하고 있는 부분을 발견하여 수정해두었습니다.


<img width="1467" alt="image" src="https://user-images.githubusercontent.com/54926467/231248293-6da93ebc-c191-4747-b0ef-1f9599e86015.png">
큰 수정은 없으니 위 이미지를 참고해주시면 좋을 것 같습니다.