### PR TITLE
Client 이메일에 대한 유효성 검사 및 Modal 컴포넌트 구현

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -11,7 +11,6 @@ import MainPage from './pages/MainPage';
 import CasesPage from './pages/CasesPage';
 import ResultPage from './pages/ResultPage';
 import ResultCheckPage from './pages/ResultCheckPage';
-import Test from './components/Modal';
 
 const App = () => {
   return (
@@ -23,7 +22,6 @@ const App = () => {
           <Route path='/cases' element={ <CasesPage /> } />
           <Route path='/check' element={<ResultCheckPage />} />
           <Route path='/result' element={<ResultPage />} />
-          <Route path='/check/tmp' element={<Test />} />
         </Routes>
         <Footer />
       </Router>

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -11,6 +11,7 @@ import MainPage from './pages/MainPage';
 import CasesPage from './pages/CasesPage';
 import ResultPage from './pages/ResultPage';
 import ResultCheckPage from './pages/ResultCheckPage';
+import Test from './components/Modal';
 
 const App = () => {
   return (
@@ -22,6 +23,7 @@ const App = () => {
           <Route path='/cases' element={ <CasesPage /> } />
           <Route path='/check' element={<ResultCheckPage />} />
           <Route path='/result' element={<ResultPage />} />
+          <Route path='/check/tmp' element={<Test />} />
         </Routes>
         <Footer />
       </Router>

--- a/front/src/components/Modal.js
+++ b/front/src/components/Modal.js
@@ -1,19 +1,19 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const ModalCheckEmail = ({ title, message1, message2, onConfirm }) => {
+const ModalCheckEmail = ({props}) => {
   return (
     <ModalContainer>
       <ModalContent>
-        <ModalHeader>{title}</ModalHeader>
+        <ModalHeader>{props.title}</ModalHeader>
         <ModalBody>
-          {message1}
+          {props.msg1}
           <br/>
-          {message2}
+          {props.msg2}
         </ModalBody>
         
         <ModalFooter>
-          <Button onClick={onConfirm}>OK</Button>
+          <Button onClick={props.onConfirm}>OK</Button>
         </ModalFooter>
       </ModalContent>
     </ModalContainer>

--- a/front/src/components/Modal.js
+++ b/front/src/components/Modal.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+
+const ModalCheckEmail = ({ title = 'Error', message = 'Email is not valid.Please check your email.', onConfirm }) => {
+  return (
+    <ModalContainer>
+      <ModalContent>
+        <ModalHeader>{title}</ModalHeader>
+        <ModalBody>{message}</ModalBody>
+        <ModalFooter>
+          <Button onClick={onConfirm}>OK</Button>
+        </ModalFooter>
+      </ModalContent>
+    </ModalContainer>
+  );
+};
+
+const ModalContainer = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  font-family: AkiraExpanded;
+`;
+
+const ModalContent = styled.div`
+  width: 25vw;
+  border-radius: 1em;
+  background-color: white;
+  box-shadow: 0 0.3em 0.5em rgba(0, 0, 0, 0.16);
+`;
+
+const ModalHeader = styled.div`
+  padding: 0.5em;
+  font-size: 1.6vw;
+  font-weight: bold;
+  text-align: center;
+`
+
+const ModalBody = styled.div`
+  padding: 1em;
+  font-size: 0.9vw;
+  text-align: center;
+`
+
+const ModalFooter = styled.div`
+  display: flex;
+  justify-content: center;
+  padding: 1em;
+`
+
+const Button = styled.button`
+  padding: 0.5em 1em;
+  border-radius: 0.7em;
+  font-size: 1em;
+  font-weight: bold;
+  color: white;
+  background-color: ${(props) => props.color || '#000000'};
+  border: none;
+  cursor: pointer;
+  font-family: AkiraExpanded;
+`
+
+
+export default ModalCheckEmail;

--- a/front/src/components/Modal.js
+++ b/front/src/components/Modal.js
@@ -1,12 +1,17 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
 
-const ModalCheckEmail = ({ title = 'Error', message = 'Email is not valid.Please check your email.', onConfirm }) => {
+const ModalCheckEmail = ({ title, message1, message2, onConfirm }) => {
   return (
     <ModalContainer>
       <ModalContent>
         <ModalHeader>{title}</ModalHeader>
-        <ModalBody>{message}</ModalBody>
+        <ModalBody>
+          {message1}
+          <br/>
+          {message2}
+        </ModalBody>
+        
         <ModalFooter>
           <Button onClick={onConfirm}>OK</Button>
         </ModalFooter>
@@ -60,7 +65,7 @@ const Button = styled.button`
   font-size: 1em;
   font-weight: bold;
   color: white;
-  background-color: ${(props) => props.color || '#000000'};
+  background-color: black;
   border: none;
   cursor: pointer;
   font-family: AkiraExpanded;

--- a/front/src/db.js
+++ b/front/src/db.js
@@ -46,4 +46,22 @@ const case_params = {
   }
 }
 
-export {dynamoDB, params, main_case_params, case_params};
+const email_params = ({email}) => {
+  const params ={
+    TableName: dbName,
+    KeyConditionExpression: "client_email = :client_email",
+    ExpressionAttributeValues: {
+        ":client_email": email
+    }
+  }
+  return params
+}
+
+
+export {
+  dynamoDB, 
+  params, 
+  main_case_params, 
+  case_params,
+  email_params,
+};

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -1,22 +1,60 @@
-import React from 'react';
+import React, {useState} from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
 import BG from '../statics/images/bg-blue.png'
-
-
+import { dynamoDB } from '../db.js';
 
 const ResultCheckPage = () => {
 	const navigate = useNavigate();
+    const [email, setEmail] = useState("");
+    const [isValid, setIsValid] = useState(true);
+
+    function handleInputChange(event) {
+        setEmail(event.target.value);
+        console.log(event.target.value)
+    }
+    function checkEmail(email) {
+        console.log('email : ', email)
+        const params = {
+          TableName: 'TF_database',
+          KeyConditionExpression: "client_email = :client_email",
+          ExpressionAttributeValues: {
+              ":client_email": email
+          }
+        };
+      
+        dynamoDB.query(params, function(err, data) {
+          if (err) {
+              setIsValid(false);
+          } else {
+              if (data.Count == 0) {
+                setIsValid(false);
+              }
+              else {
+                setIsValid(true);
+              }
+              // console.log(data, data.Count);
+          }
+        });
+    }
+    function handleFormSubmit(event) {
+        event.preventDefault();
+        checkEmail(email);
+    }
+
 	return (
 		<PageContainer>
 			<Title>
                 -<br/>
                 Check the result
             </Title>
-            <InputContainer>
-                <InputSection placeholder='Please enter your email'></InputSection>
+            <InputContainer onSubmit={handleFormSubmit}>
+                <InputSection placeholder='Please enter your email' value={email} onChange={handleInputChange}></InputSection>
                 {/* 임시로 DONE 버튼을 누르면 result 페이지로 이동하도록 해두었습니다. */}
-                <InputBtn onClick={() => navigate('/result')}>DONE</InputBtn> 
+                {/* <InputBtn onClick={() => navigate('/result')}>DONE</InputBtn>  */}
+                <InputBtn >DONE</InputBtn> 
+                {!isValid && <p>Email is invalid</p>}
+                {isValid && <p>Email is f</p>}
             </InputContainer>
 		</PageContainer>
 	);
@@ -41,7 +79,7 @@ const Title = styled.span`
     text-align: center;
 `
 
-const InputContainer = styled.div`
+const InputContainer = styled.form`
     margin: 3%;
 `
 const InputSection = styled.input`

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -1,20 +1,21 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import BG from '../statics/images/bg-blue.png'
 import { dynamoDB } from '../db.js';
+import BG from '../statics/images/bg-blue.png'
+import Modal from '../components/Modal';
 
 const ResultCheckPage = () => {
 	const navigate = useNavigate();
     const [email, setEmail] = useState("");
     const [isValid, setIsValid] = useState(true);
+    const [modalOpen, setModalOpen] = useState(false);
 
     function handleInputChange(e) {
         setEmail(e.target.value);
     }
 
     function checkEmail(email) {
-        console.log('email : ', email)
         const params = {
           TableName: 'TF_database',
           KeyConditionExpression: "client_email = :client_email",
@@ -26,11 +27,14 @@ const ResultCheckPage = () => {
         dynamoDB.query(params, function(err, data) {
           if (err) {
               setIsValid(false);
+              setModalOpen(true);
           } else {
               if (data.Count == 0) {
                 setIsValid(false);
+                setModalOpen(true);
               }
               else {
+                // 이메일 유효시 result 페이지로 이동
                 navigate('/result');
               }
           }
@@ -40,9 +44,12 @@ const ResultCheckPage = () => {
     function handleFormSubmit(e) {
         e.preventDefault();
         checkEmail(email);
-
     }
 
+    const handleClickModal = () => {
+        setModalOpen(false);
+        setEmail('');
+    };
 
 	return (
 		<PageContainer>
@@ -52,10 +59,15 @@ const ResultCheckPage = () => {
             </Title>
             <InputContainer onSubmit={handleFormSubmit}>
                 <InputSection placeholder='Please enter your email' value={email} onChange={handleInputChange}></InputSection>
-                {/* 임시로 DONE 버튼을 누르면 result 페이지로 이동하도록 해두었습니다. */}
-                {/* <InputBtn onClick={() => navigate('/result')}>DONE</InputBtn>  */}
                 <InputBtn >DONE</InputBtn> 
-                {!isValid && <p>Email is invalid</p>}
+                {!isValid && modalOpen &&
+                    <Modal 
+                        title='🚨 Error 🚨' 
+                        message1='Email is not valid' 
+                        message2='Please check your email'
+                        onConfirm={handleClickModal}
+                    />
+                }
 
 
             </InputContainer>

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -9,8 +9,8 @@ const ResultCheckPage = () => {
     const [email, setEmail] = useState("");
     const [isValid, setIsValid] = useState(true);
 
-    function handleInputChange(event) {
-        setEmail(event.target.value);
+    function handleInputChange(e) {
+        setEmail(e.target.value);
     }
 
     function checkEmail(email) {

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -11,8 +11,8 @@ const ResultCheckPage = () => {
 
     function handleInputChange(event) {
         setEmail(event.target.value);
-        console.log(event.target.value)
     }
+
     function checkEmail(email) {
         console.log('email : ', email)
         const params = {
@@ -31,16 +31,18 @@ const ResultCheckPage = () => {
                 setIsValid(false);
               }
               else {
-                setIsValid(true);
+                navigate('/result');
               }
-              // console.log(data, data.Count);
           }
         });
     }
-    function handleFormSubmit(event) {
-        event.preventDefault();
+
+    function handleFormSubmit(e) {
+        e.preventDefault();
         checkEmail(email);
+
     }
+
 
 	return (
 		<PageContainer>
@@ -54,7 +56,8 @@ const ResultCheckPage = () => {
                 {/* <InputBtn onClick={() => navigate('/result')}>DONE</InputBtn>  */}
                 <InputBtn >DONE</InputBtn> 
                 {!isValid && <p>Email is invalid</p>}
-                {isValid && <p>Email is f</p>}
+
+
             </InputContainer>
 		</PageContainer>
 	);

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -1,7 +1,7 @@
 import React, {useState} from 'react';
 import styled from 'styled-components';
 import { useNavigate } from 'react-router-dom';
-import { dynamoDB } from '../db.js';
+import { dynamoDB, email_params } from '../db.js';
 import BG from '../statics/images/bg-blue.png'
 import Modal from '../components/Modal';
 
@@ -16,13 +16,7 @@ const ResultCheckPage = () => {
     }
 
     function checkEmail(email) {
-        const params = {
-          TableName: 'TF_database',
-          KeyConditionExpression: "client_email = :client_email",
-          ExpressionAttributeValues: {
-              ":client_email": email
-          }
-        };
+        const params = email_params(email = {email});
       
         dynamoDB.query(params, function(err, data) {
           if (err) {

--- a/front/src/pages/ResultCheckPage.js
+++ b/front/src/pages/ResultCheckPage.js
@@ -45,6 +45,13 @@ const ResultCheckPage = () => {
         setEmail('');
     };
 
+    const modalProps = {
+        title: '🚨 Error 🚨',
+        msg1: 'Email is not valid',
+        msg2: 'Please check your email',
+        onConfirm: handleClickModal
+      };
+
 	return (
 		<PageContainer>
 			<Title>
@@ -55,12 +62,7 @@ const ResultCheckPage = () => {
                 <InputSection placeholder='Please enter your email' value={email} onChange={handleInputChange}></InputSection>
                 <InputBtn >DONE</InputBtn> 
                 {!isValid && modalOpen &&
-                    <Modal 
-                        title='🚨 Error 🚨' 
-                        message1='Email is not valid' 
-                        message2='Please check your email'
-                        onConfirm={handleClickModal}
-                    />
+                    <Modal props={modalProps} />
                 }
 
 


### PR DESCRIPTION
### Client 이메일에 대한 유효성 검사 및 Modal 컴포넌트 구현
/check 에서 Client의 이메일에 대한 유효성 검사 및 재활용 가능한 Modal 컴포넌트를 구현했습니다.

<img width="832" alt="image" src="https://user-images.githubusercontent.com/54926467/232982609-6b5f4e7f-7bc8-4d28-b4f9-ff5f73251088.png">

- AWS의 DataBase를 연결했습니다. 
- dynamoDB query를 통해 client_email의 유효성 검사를 진행합니다.
- DB에 있는 이메일을 입력하면 /result로 이동합니다. 
- 현재는 단순 페이지 이동만 구현되어 있습니다. client에 대한 정보를 /result로 넘겨주고 있지 않습니다. /result에 대한 DB연결을 제가 하지 않았으므로 이 부분은 구현 보류상태이며, 이는 이 부분을 담당하신 @ChanHHOO 의 code merge 이후 개발 진행이 될 것 같습니다.

<img width="820" alt="image" src="https://user-images.githubusercontent.com/54926467/232983368-b012d4d2-45ab-461e-b58a-a29159a2269f.png">
<img width="766" alt="image" src="https://user-images.githubusercontent.com/54926467/232983424-8b583751-b955-4697-87c6-1d1127319bf8.png">

- 잘못된 이메일을 입력할 경우 modal 컴포넌트가 나오도록 구현했습니다.
- modal 컴포넌트는 이 프로젝트 내에 언제나 재활용이 가능하도록 구현했습니다.
- OK 버튼을 누르면 modal이 사라지며, input 창의 text도 초기화되도록 설정했습니다.